### PR TITLE
Fix Ruby example for ticket creation with attachment

### DIFF
--- a/Ruby/ticket_create_with_attachment.rb
+++ b/Ruby/ticket_create_with_attachment.rb
@@ -1,10 +1,10 @@
-#Create a ticket with attachments. 
+#Create a ticket with attachments.
 require 'rubygems'
-require "rest_client"
+require 'rest_client'
 require 'json'
 
 # Your freshdesk domain
-fd_domain = 'YOUR_DOMAIN'
+freshdesk_domain = 'YOUR_DOMAIN'
 
 # It could be either your user name or api_key.
 user_name_or_api_key = 'YOUR_API_KEY'
@@ -13,24 +13,24 @@ user_name_or_api_key = 'YOUR_API_KEY'
 password_or_x = 'X'
 
 #attachments should be of the form array of Hash with files mapped to the key 'resource'.
-multipart_payload = { :status => 2, 
-                      :priority => 1, 
-                      :email=>"test@xyz.com",
-                      :description_html=>"<strong>Hi there</strong>Ticket with attachment",
-                      :subject=>"hello",
-                      :attachments=>[File.new("/path/to/your/file.png", 'rb'), File.new("/path/to/your/file2.png", 'rb')]}
+multipart_payload = { status: 2,
+                      priority: 1,
+                      email: 'test@xyz.com',
+                      description: '<strong>Hi there</strong>Ticket with attachment',
+                      subject: 'hello',
+                      attachments: [File.new('/path/to/your/file.png', 'rb'), File.new('/path/to/your/file2.png', 'rb')]}
 
-api_path = "api/v2/tickets"
+freshdesk_api_path = 'api/v2/tickets'
 
-api_url  = "https://#{fd_domain}.freshdesk.com/#{api_path}"
+freshdesk_api_url  = "https://#{freshdesk_domain}.freshdesk.com/#{freshdesk_api_path}"
 
-site = RestClient::Resource.new(api_url, user_name_or_api_key, password_or_x)
+site = RestClient::Resource.new(freshdesk_api_url, user_name_or_api_key, password_or_x)
 
 begin
   response = site.post(multipart_payload)
   puts "response_code: #{response.code} \nLocation Header: #{response.headers[:Location]} \nresponse_body: #{response.body} \n"
 rescue RestClient::Exception => exception
-  puts "API Error: Your request is not successful. If you are not able to debug this error properly, mail us at support@freshdesk.com with the follwing X-Request-Id"
+  puts 'API Error: Your request is not successful. If you are not able to debug this error properly, mail us at support@freshdesk.com with the follwing X-Request-Id'
   puts "X-Request-Id : #{exception.response.headers[:x_request_id]}"
   puts "Response Code: #{exception.response.code} \nResponse Body: #{exception.response.body} \n"
 end


### PR DESCRIPTION
The field **description_html** was rename to description in order to
pass the fields validation of Freshdesk API.
The syntaxis for ruby was update and strings without **interpolation**
were declared differently. closes #31 