### PR TITLE
Fix custom-fields to support tags in Ticket Creation

### DIFF
--- a/NodeJs/create_ticket_custom_fields_and_attachements.js
+++ b/NodeJs/create_ticket_custom_fields_and_attachements.js
@@ -11,14 +11,16 @@ var PATH = "/api/v2/tickets";
 var enocoding_method = "base64";
 var auth = "Basic " + new Buffer(API_KEY + ":" + 'X').toString(enocoding_method);
 var URL =  "https://" + FD_ENDPOINT + ".freshdesk.com"+ PATH;
-
+var tags = ['Testing1', 'Testing2'];
+var custom_fields = {'department': 'IT'};
 var fields = {
   'email': 'email@yourdomain.com',
   'subject': 'Ticket subject',
   'description': 'Ticket description.',
   'status': 2,
   'priority': 1,
-  'custom_fields[department]':'IT'
+  'tags': tags,
+  'custom_fields':custom_fields
 }
 
 var headers = {


### PR DESCRIPTION
**What?**
- This PR changes the way of passing custom_fields when a user wants to pass tags array along with it to create ticket.

**Why?**
-If we try to send tags along with custom_fields in post api call as mentioned in the example, it always gives datatype_mismatch error for tags even though tags is in Array datatype.
- Many users faced issue in passing tags array along with custom_fields in ticket creation for api call. There was no relevant example for this case. 
-So adding this change (to pass custom fields as separate dictionary variable) will resolve the user queries related to the errors occurring for datatype_mismatch in the _above case_. 